### PR TITLE
[Feature] create PDF using pdfkit

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ example :
 [imapbox]
 local_folder=/var/imapbox
 days=6
+wkhtmltopdf=/opt/bin/wkhtmltopdf
 
 [account1]
 host=mail.autistici.org
@@ -70,6 +71,7 @@ Parameter       | Description
 ----------------|----------------------
 local_folder    | the full path to the folder where the emails are stored. If the local_folder is not set, imapbox will download the emails in the current directory. This can be overwwritten with the shell argument -l
 days            | number of days back to get in the imap account, this should be set greater and equals to the cronjob frequency. If this parameter is not set, imapbox will get all the emails from the imap account. This can be overwwritten with the shell argument -d
+wkhtmltopdf     | the location of the `wkhtmltopdf` binary. By default `pdfkit` will attempt to locate this using `which` (on UNIX type systems) or `where` (on Windows).
 
 
 

--- a/README.md
+++ b/README.md
@@ -1,19 +1,18 @@
 ![IMAPBOX](logo.png)
 
-
-
-Dump imap inbox to a local folder in a regular backupable format: html, json and attachements.
+Dump IMAP inbox to a local folder in a regular backupable format: HTML, JSON and attachments.
 
 This program aims to save a mailbox for archive using files in indexable or searchable formats.
-The produced files should be readables without external software, for example, to find an email in backups using only the terminal
+The produced files should be readable without external software, for example, to find an email in backups using only the terminal.
 
-For each email in the imap mailbox, create a folder with the following content:
+For each email in the IMAP mailbox, create a folder with the following content:
 
-* __message.html__ if an html part exists for the message body. the message.html will allways be in utf-8, the embeded images links are modified to refer to the attachments subfolder
-* __attachements__ The attachements folder contains the attached files and the embeded images
-* __message.txt__ this file contain the body text if available in the original email, allways converted in utf-8
-* __metadata.json__ Various informations in JSON format, date, recipients, body text, etc... This file can be used from external applications or a search engine like [elasticsearch](http://www.elasticsearch.com/)
-* __raw.eml.gz__ A gziped version of the email in eml format
+* __message.html__ - If an html part exists for the message body. the `message.html` will always be in UTF-8, the embedded images links are modified to refer to the attachments subfolder.
+* __message.pdf__ - This file is created from `message.html` when the `wkhtmltopdf` option is set in the config file.
+* __attachments__ - The attachments folder contains the attached files and the embeded images.
+* __message.txt__ - This file contain the body text if available in the original email, always converted in UTF-8.
+* __metadata.json__ - Various informations in JSON format, date, recipients, body text, etc... This file can be used from external applications or a search engine like [elasticsearch](http://www.elasticsearch.com/).
+* __raw.eml.gz__ - A gziped version of the email in `.eml` format.
 
 Imapbox was designed to archive multiple mailboxes in one common directory tree,
 copies of the same message spread knew several account will be archived once using the Message-Id property.
@@ -27,14 +26,15 @@ You need python 2 to run this script, and the [chardet](https://pypi.python.org/
 * I use the script to merge all my mail accounts in one searchable directory on my NAS server.
 * Report on a website the content of an email address, like a mailing list.
 * Sharing address of several employees to perform cross-searches on a common database.
-* Archiving an imap account because of mailbox size restrictions, or to restrain the used disk space on the imap server
+* Archiving an IMAP account because of mailbox size restrictions, or to restrain the used disk space on the IMAP server.
+* Archiving emails to PDF format.
 
 
 ## Config file
 
-in ~/.config/imapbox/config.cfg or /etc/imapbox/config.cfg
+Use `~/.config/imapbox/config.cfg` or `/etc/imapbox/config.cfg`
 
-example :
+Example:
 ```ini
 [imapbox]
 local_folder=/var/imapbox
@@ -52,32 +52,24 @@ username=username@gmail.com
 password=secret
 remote_folder=INBOX
 port=993
-
 ```
-
-
-
-
 
 
 
 The imapbox section
 -------------------
 
-
 Possibles parameters for the imapbox section:
 
 Parameter       | Description
 ----------------|----------------------
-local_folder    | the full path to the folder where the emails are stored. If the local_folder is not set, imapbox will download the emails in the current directory. This can be overwwritten with the shell argument -l
-days            | number of days back to get in the imap account, this should be set greater and equals to the cronjob frequency. If this parameter is not set, imapbox will get all the emails from the imap account. This can be overwwritten with the shell argument -d
-wkhtmltopdf     | the location of the `wkhtmltopdf` binary. By default `pdfkit` will attempt to locate this using `which` (on UNIX type systems) or `where` (on Windows).
+local_folder    | The full path to the folder where the emails are stored. If the local_folder is not set, imapbox will download the emails in the current directory. This can be overwritten with the shell argument `-l`.
+days            | Number of days back to get in the IMAP account, this should be set greater and equals to the cronjob frequency. If this parameter is not set, imapbox will get all the emails from the IMAP account. This can be overwritten with the shell argument `-d`.
+wkhtmltopdf     | (optional) The location of the `wkhtmltopdf` binary. By default `pdfkit` will attempt to locate this using `which` (on UNIX type systems) or `where` (on Windows). This can be overwritten with the shell argument `-w`.
 
 
 
-
-
-other sections
+Other sections
 --------------
 
 You can have has many configured account as you want, one per section. Sections names may contains the account name.
@@ -86,13 +78,11 @@ Possibles parameters for an account section:
 
 Parameter       | Description
 ----------------|----------------------
-host            | Imap server hostname
-username        | login id for the imap server
-password        | The password will be saved in cleartext, for security reasons, you have to run the imapbox script in userspace and set chmod 700 on you ~/.config/mailbox/config.cfg file
-remote_folder   | optional parameter, imap foldername (multiple foldername is not supported for the moment). Default value is INBOX
-port            | optional parameter, default value is 993
-
-
+host            | IMAP server hostname
+username        | Login id for the IMAP server.
+password        | The password will be saved in cleartext, for security reasons, you have to run the imapbox script in userspace and set `chmod 700` on your `~/.config/mailbox/config.cfg` file.
+remote_folder   | (optional) IMAP folder name (multiple folder name is not supported for the moment). Default value is `INBOX`.
+port            | (optional) Default value is `993`.
 
 
 
@@ -106,16 +96,16 @@ From            | Name and email of the sender
 To              | An array of recipients
 Cc              | An array of recipients
 Attachments     | An array of files names
-Date            | Message date with the timezone included, in the RFC 2822 format
-Utc             | Message date converted in UTC, in the ISO 8601 format. This can be used to sort emails or filter emails by date
-WithHtml        | Boolean, if the message.html file exists or not
-WithText        | Boolean, if the message.txt file exists or not
+Date            | Message date with the timezone included, in the `RFC 2822` format
+Utc             | Message date converted in UTC, in the `ISO 8601` format. This can be used to sort emails or filter emails by date
+WithHtml        | Boolean, if the `message.html` file exists or not
+WithText        | Boolean, if the `message.txt` file exists or not
 
 
 ## Elasticsearch
 
-The metadata.json file contain the necessary informations for a search engine like [elasticsearch](http://www.elasticsearch.com/).
-Populate an elasticsearch index with the emails metadata can be done with a simple script
+The `metadata.json` file contain the necessary informations for a search engine like [Elasticsearch](http://www.elasticsearch.com/).
+Populate an Elasticsearch index with the emails metadata can be done with a simple script.
 
 Create an index:
 ```bash

--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ copies of the same message spread knew several account will be archived once usi
 ## Install
 
 This script requires python 2 and the following libraries:
-* [chardet](https://pypi.python.org/pypi/chardet) library – required for character encoding detection.
-* (optional) [pdfkit](https://pypi.python.org/pypi/pdfkit) library – required for archiving emails to PDF.
+* [chardet](https://pypi.python.org/pypi/chardet) – required for character encoding detection.
+* [pdfkit](https://pypi.python.org/pypi/pdfkit) – optionally required for archiving emails to PDF.
 
 ## Use cases
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![IMAPBOX](logo.png)
 
-Dump IMAP inbox to a local folder in a regular backupable format: HTML, JSON and attachments.
+Dump IMAP inbox to a local folder in a regular backupable format: HTML, PDF, JSON and attachments.
 
 This program aims to save a mailbox for archive using files in indexable or searchable formats.
 The produced files should be readable without external software, for example, to find an email in backups using only the terminal.

--- a/README.md
+++ b/README.md
@@ -2,24 +2,27 @@
 
 Dump IMAP inbox to a local folder in a regular backupable format: HTML, PDF, JSON and attachments.
 
-This program aims to save a mailbox for archive using files in indexable or searchable formats.
-The produced files should be readable without external software, for example, to find an email in backups using only the terminal.
+This program aims to save a mailbox for archive using files in indexable or searchable formats. The produced files should be readable without external software, for example, to find an email in backups using only the terminal.
 
-For each email in the IMAP mailbox, create a folder with the following content:
+For each email in an IMAP mailbox, a folder is created with the following files:
 
-* __message.html__ - If an html part exists for the message body. the `message.html` will always be in UTF-8, the embedded images links are modified to refer to the attachments subfolder.
-* __message.pdf__ - This file is created from `message.html` when the `wkhtmltopdf` option is set in the config file.
-* __attachments__ - The attachments folder contains the attached files and the embeded images.
-* __message.txt__ - This file contain the body text if available in the original email, always converted in UTF-8.
-* __metadata.json__ - Various informations in JSON format, date, recipients, body text, etc... This file can be used from external applications or a search engine like [Elasticsearch](http://www.elasticsearch.com/).
-* __raw.eml.gz__ - A gziped version of the email in `.eml` format.
+File              | Description
+------------------|------------------
+__message.html__  | If an html part exists for the message body. the `message.html` will always be in UTF-8, the embedded images links are modified to refer to the attachments subfolder.
+__message.pdf__   | This file is optionally created from `message.html` when the `wkhtmltopdf` option is set in the config file.
+__attachments__   | The attachments folder contains the attached files and the embeded images.
+__message.txt__   | This file contain the body text if available in the original email, always converted in UTF-8.
+__metadata.json__ | Various informations in JSON format, date, recipients, body text, etc... This file can be used from external applications or a search engine like [Elasticsearch](http://www.elasticsearch.com/).
+__raw.eml.gz__    | A gziped version of the email in `.eml` format.
 
 Imapbox was designed to archive multiple mailboxes in one common directory tree,
 copies of the same message spread knew several account will be archived once using the Message-Id property.
 
 ## Install
 
-You need python 2 to run this script, and the [chardet](https://pypi.python.org/pypi/chardet) library.
+This script requires python 2 and the following libraries:
+* [chardet](https://pypi.python.org/pypi/chardet) library – required for character encoding detection.
+* (optional) [pdfkit](https://pypi.python.org/pypi/pdfkit) library – required for archiving emails to PDF.
 
 ## Use cases
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ For each email in the IMAP mailbox, create a folder with the following content:
 * __message.pdf__ - This file is created from `message.html` when the `wkhtmltopdf` option is set in the config file.
 * __attachments__ - The attachments folder contains the attached files and the embeded images.
 * __message.txt__ - This file contain the body text if available in the original email, always converted in UTF-8.
-* __metadata.json__ - Various informations in JSON format, date, recipients, body text, etc... This file can be used from external applications or a search engine like [elasticsearch](http://www.elasticsearch.com/).
+* __metadata.json__ - Various informations in JSON format, date, recipients, body text, etc... This file can be used from external applications or a search engine like [Elasticsearch](http://www.elasticsearch.com/).
 * __raw.eml.gz__ - A gziped version of the email in `.eml` format.
 
 Imapbox was designed to archive multiple mailboxes in one common directory tree,

--- a/README.md
+++ b/README.md
@@ -147,3 +147,8 @@ find . -name "*.json" | xargs cat | jq 'select(.Utc > "20150221T130000Z")'
 ## Similar projects
 
 [NoPriv](https://github.com/RaymiiOrg/NoPriv) is a python script to backup any IMAP capable email account to a browsable HTML archive and a Maildir folder.
+
+
+## License
+
+The MIT License (MIT)

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Possibles parameters for the imapbox section:
 
 Parameter       | Description
 ----------------|----------------------
-local_folder    | The full path to the folder where the emails are stored. If the local_folder is not set, imapbox will download the emails in the current directory. This can be overwritten with the shell argument `-l`.
+local_folder    | The full path to the folder where the emails should be stored. If the local_folder is not set, imapbox will download the emails in the current directory. This can be overwritten with the shell argument `-l`.
 days            | Number of days back to get in the IMAP account, this should be set greater and equals to the cronjob frequency. If this parameter is not set, imapbox will get all the emails from the IMAP account. This can be overwritten with the shell argument `-d`.
 wkhtmltopdf     | (optional) The location of the `wkhtmltopdf` binary. By default `pdfkit` will attempt to locate this using `which` (on UNIX type systems) or `where` (on Windows). This can be overwritten with the shell argument `-w`.
 

--- a/imapbox.py
+++ b/imapbox.py
@@ -26,7 +26,7 @@ def load_configuration(args):
         if config.has_option('imapbox', 'local_folder'):
             options['local_folder'] = os.path.expanduser(config.get('imapbox', 'local_folder'))
 
-        if config.has_option('imapbox', 'wkhtmltopdf')
+        if config.has_option('imapbox', 'wkhtmltopdf'):
             options['wkhtmltopdf'] = os.path.expanduser(config.get('imapbox', 'wkhtmltopdf'))
 
 

--- a/imapbox.py
+++ b/imapbox.py
@@ -86,7 +86,7 @@ def main():
         stats = mailbox.copy_emails(options['days'], options['local_folder'], options['wkhtmltopdf'])
         mailbox.cleanup()
 
-        print('{} emails created, {} emails allready exists'.format(stats[0], stats[1]))
+        print('{} emails created, {} emails already exists'.format(stats[0], stats[1]))
 
 
 if __name__ == '__main__':

--- a/imapbox.py
+++ b/imapbox.py
@@ -15,6 +15,7 @@ def load_configuration(args):
     options = {
         'days': None,
         'local_folder': '.',
+        'wkhtmltopdf': None,
         'accounts': []
     }
 
@@ -24,6 +25,10 @@ def load_configuration(args):
 
         if config.has_option('imapbox', 'local_folder'):
             options['local_folder'] = os.path.expanduser(config.get('imapbox', 'local_folder'))
+
+        if config.has_option('imapbox', 'wkhtmltopdf')
+            options['wkhtmltopdf'] = os.path.expanduser(config.get('imapbox', 'wkhtmltopdf'))
+
 
     for section in config.sections():
 
@@ -57,6 +62,9 @@ def load_configuration(args):
     if (args.days):
         options['days'] = args.days
 
+    if (args.wkhtmltopdf):
+        options['wkhtmltopdf'] = args.wkhtmltopdf
+
     return options
 
 
@@ -66,6 +74,7 @@ def main():
     argparser = argparse.ArgumentParser(description="Dump a IMAP folder into .eml files")
     argparser.add_argument('-l', dest='local_folder', help="Local folder where to create the email folders")
     argparser.add_argument('-d', dest='days', help="Local folder where to create the email folders", type=int)
+    argparser.add_argument('-w', dest='wkhtmltopdf', help="The location of the wkhtmltopdf binary")
     args = argparser.parse_args()
     options = load_configuration(args)
 
@@ -74,7 +83,7 @@ def main():
         print('{}/{} (on {})'.format(account['name'], account['remote_folder'], account['host']))
 
         mailbox = MailboxClient(account['host'], account['port'], account['username'], account['password'], account['remote_folder'])
-        stats = mailbox.copy_emails(options['days'], options['local_folder'])
+        stats = mailbox.copy_emails(options['days'], options['local_folder'], options['wkhtmltopdf'])
         mailbox.cleanup()
 
         print('{} emails created, {} emails allready exists'.format(stats[0], stats[1]))

--- a/mailboxresource.py
+++ b/mailboxresource.py
@@ -18,12 +18,13 @@ class MailboxClient:
         self.mailbox.login(username, password)
         self.mailbox.select(remote_folder, readonly=True)
 
-    def copy_emails(self, days, local_folder):
+    def copy_emails(self, days, local_folder, wkhtmltopdf):
 
         n_saved = 0
         n_exists = 0
 
         self.local_folder = local_folder
+        self.wkhtmltopdf = wkhtmltopdf
         criterion = 'ALL'
 
         if days:
@@ -70,7 +71,7 @@ class MailboxClient:
                 directory = self.getEmailFolder(msg, data[0][1])
 
                 if os.path.exists(directory):
-                    return False;
+                    return False
 
                 os.makedirs(directory)
 
@@ -79,6 +80,10 @@ class MailboxClient:
                     message.createRawFile(data[0][1])
                     message.createMetaFile()
                     message.extractAttachments()
+
+                    if self.wkhtmltopdf:
+                        message.createPdfFile(self.wkhtmltopdf)
+
                 except StandardError as e:
                     # ex: Unsupported charset on decode
                     print directory
@@ -88,4 +93,4 @@ class MailboxClient:
                         print "MailboxClient.saveEmail() failed"
                         print e
 
-        return True;
+        return True

--- a/message.py
+++ b/message.py
@@ -15,6 +15,7 @@ import gzip
 import cgi
 from HTMLParser import HTMLParser
 import time
+import pdfkit
 
 
 # email address REGEX matching the RFC 2822 spec
@@ -214,7 +215,7 @@ class Message:
     def createHtmlFile(self, parts, embed):
         utf8_content = self.getHtmlContent(parts)
         for img in embed:
-            pattern = 'src=["\']cid:%s["\']' % (re.escape(img[0]));
+            pattern = 'src=["\']cid:%s["\']' % (re.escape(img[0]))
             path = os.path.join('attachments', img[1].encode('utf8','replace'))
             utf8_content = re.sub(pattern, 'src="%s"' % (path), utf8_content, 0, re.S | re.I)
 
@@ -309,3 +310,10 @@ class Message:
                     payload = afile[0].get_payload(decode=True)
                     if payload:
                         fp.write(payload)
+
+
+    def createPdfFile(self, wkhtmltopdf):
+        html_path = os.path.join(self.directory, 'message.html')
+        pdf_path = os.path.join(self.directory, 'message.pdf')
+        config = pdfkit.configuration(wkhtmltopdf=wkhtmltopdf)
+        pdfkit.from_file(html_path, pdf_path, configuration=config)

--- a/message.py
+++ b/message.py
@@ -15,7 +15,11 @@ import gzip
 import cgi
 from HTMLParser import HTMLParser
 import time
-import pdfkit
+import pkgutil
+
+# import pdfkit if its loader is available
+has_pdfkit = pkgutil.find_loader('pdfkit') is not None
+if has_pdfkit: import pdfkit
 
 
 # email address REGEX matching the RFC 2822 spec
@@ -41,7 +45,6 @@ domain="(?:"  +  dot_atom  +  "|"  +  domain_lit  +  ")"
 addr_spec=local  +  "\@"  +  domain
 
 email_address_re=re.compile('^'+addr_spec+'$')
-
 
 
 
@@ -313,7 +316,8 @@ class Message:
 
 
     def createPdfFile(self, wkhtmltopdf):
-        html_path = os.path.join(self.directory, 'message.html')
-        pdf_path = os.path.join(self.directory, 'message.pdf')
-        config = pdfkit.configuration(wkhtmltopdf=wkhtmltopdf)
-        pdfkit.from_file(html_path, pdf_path, configuration=config)
+        if has_pdfkit:
+            html_path = os.path.join(self.directory, 'message.html')
+            pdf_path = os.path.join(self.directory, 'message.pdf')
+            config = pdfkit.configuration(wkhtmltopdf=wkhtmltopdf)
+            pdfkit.from_file(html_path, pdf_path, configuration=config)

--- a/message.py
+++ b/message.py
@@ -321,3 +321,5 @@ class Message:
             pdf_path = os.path.join(self.directory, 'message.pdf')
             config = pdfkit.configuration(wkhtmltopdf=wkhtmltopdf)
             pdfkit.from_file(html_path, pdf_path, configuration=config)
+        else:
+            print "Couldn't create PDF message, since \"pdfkit\" module isn't installed."


### PR DESCRIPTION
This converts `message.html` to `message.pdf` using `pdfkit`, which requires `wkhtmltopdf`. It also corrects some spelling, improves the readability of `README` and adds the License section.

I added an optional option `wkhtmltopdf` for the imapbox section in the config, which should point to a `wkhtmltopdf` binary.

**As I'm no python guru, this should be reviewed and tested please.** 😁

This could be further improved by enabling PDF creation without explicitly having to define the path to the `wkhtmltopdf` binary in the config file, but instead using the `wkhtmltopdf` command defined in `$PATH`.

I'm open to discussions and would be happy to see this merged, if it's useful to somebody else.
Thanks !