### PR TITLE
Be able to specify only one account from config file as parameter

### DIFF
--- a/imapbox.py
+++ b/imapbox.py
@@ -35,6 +35,9 @@ def load_configuration(args):
         if ('imapbox' == section):
             continue
 
+        if (args.specific_account and (args.specific_account != section)):
+            continue
+
         account = {
             'name': section,
             'remote_folder': 'INBOX',
@@ -75,6 +78,7 @@ def main():
     argparser.add_argument('-l', dest='local_folder', help="Local folder where to create the email folders")
     argparser.add_argument('-d', dest='days', help="Local folder where to create the email folders", type=int)
     argparser.add_argument('-w', dest='wkhtmltopdf', help="The location of the wkhtmltopdf binary")
+    argparser.add_argument('-a', dest='specific_account', help="Select a specific account to backup")
     args = argparser.parse_args()
     options = load_configuration(args)
 


### PR DESCRIPTION
Hi,
I think that this could be useful to someone else.

It basically allows you to specify another parameter which would be the name of the account from the config file you want to backup.

config.cfg
```
[account_that_i_dont_want_to_sync]
host=imap.mail.com
username=somemail@mail.com
password=mysecretpasword
remote_folder=INBOX
port=993

[my_favourite_account]
host=imap.mail.com
username=somemail@mail.com
password=mysecretpasword
remote_folder=INBOX
port=993
```

You could do this now:
```bash
python imapbox.py -a 'my_favourite_account'
```

Because perhaps you may want to cronjob in different hours each one. Other alternative could be to be able to specify the config file as parameter but I think this is another solution for the same case.

Regards,
Filis.

Thank you for this!