### PR TITLE
Improve email decoding

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,22 @@
+# EditorConfig helps developers define and maintain consistent
+# coding styles between different editors and IDEs
+# editorconfig.org
+
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+trim_trailing_whitespace = true
+insert_final_newline = false
+indent_style = space
+indent_size = 2
+
+[*.md]
+trim_trailing_whitespace = false
+
+[*.snap]
+trim_trailing_whitespace = false
+
+[*.js]
+insert_final_newline = true

--- a/.editorconfig
+++ b/.editorconfig
@@ -8,15 +8,12 @@ root = true
 charset = utf-8
 end_of_line = lf
 trim_trailing_whitespace = true
-insert_final_newline = false
+insert_final_newline = true
 indent_style = space
-indent_size = 2
+indent_size = 4
 
 [*.md]
 trim_trailing_whitespace = false
 
 [*.snap]
 trim_trailing_whitespace = false
-
-[*.js]
-insert_final_newline = true

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,21 @@
+## Windows
+Thumbs.db
+Desktop.ini
+$RECYCLE.BIN/
+
+## OS X
+.DS_Store
+.AppleDouble
+.LSOverride
+Icon
+._*
+.Spotlight-V100
+.Trashes
+
+## Sublime Text
+*.sublime*
+
+## Python
 __pycache__/
 *.py[cod]
-.tags
+*$py.class

--- a/.gitignore
+++ b/.gitignore
@@ -12,10 +12,13 @@ Icon
 .Spotlight-V100
 .Trashes
 
-## Sublime Text
-*.sublime*
-
 ## Python
 __pycache__/
 *.py[cod]
 *$py.class
+
+## Sublime Text
+*.sublime*
+
+## IMAPBox
+archive

--- a/imapbox.py
+++ b/imapbox.py
@@ -7,6 +7,7 @@ import configparser
 from mailboxresource import MailboxClient
 
 logging.basicConfig(
+    filename='imapbox.log',
     format='%(asctime)s - %(levelname)s - %(message)s',
     datefmt='%Y-%m-%dТ%H:%M:%S%z',
     level=logging.INFO

--- a/imapbox.py
+++ b/imapbox.py
@@ -33,7 +33,7 @@ def load_configuration(args):
             'port': section.get('port', args.port),
             'username': section.get('username', args.username),
             'password': section.get('password', args.password),
-            'imap_folder': section.get('imap_folder', args.imap_folder)
+            'remote_folder': section.get('remote_folder', args.remote_folder)
         }
 
         if (account['host'] is None or account['username'] is None or account['password'] is None):
@@ -84,7 +84,7 @@ def main():
     )
     argparser.add_argument(
         '-r',
-        dest='imap_folder',
+        dest='remote_folder',
         help='Remote IMAP folder that should be backed up',
         default='INBOX'
     )
@@ -108,7 +108,7 @@ def main():
 
         print('{}/{} (on {}:{})'.format(
             account['name'],
-            account['imap_folder'],
+            account['remote_folder'],
             account['host'],
             account['port']
             )
@@ -120,7 +120,7 @@ def main():
 
         print('{}/{}: {} emails created, {} emails already existed'.format(
             account['name'],
-            account['imap_folder'],
+            account['remote_folder'],
             stats[0],
             stats[1]
             )

--- a/imapbox.py
+++ b/imapbox.py
@@ -126,7 +126,7 @@ def main():
         mailbox.cleanup()
 
         logging.info(
-            '[%s/%s] %s emails created, %s emails already existed;',
+            '[%s/%s] %s emails downloaded, %s emails already existed;',
             account['name'],
             account['remote_folder'],
             stats[0],

--- a/imapbox.py
+++ b/imapbox.py
@@ -51,12 +51,12 @@ def main():
     argparser.add_argument(
         '-host',
         dest='host',
-        help='IMAP host'
+        help='IMAP server host name'
     )
     argparser.add_argument(
         '-port',
         dest='port',
-        help='IMAP port',
+        help='IMAP server port',
         type=int,
         default=993
     )
@@ -91,7 +91,7 @@ def main():
     argparser.add_argument(
         '-d',
         dest='days',
-        help='Local folder where to create the email folders',
+        help='How many days of correspondence to back up',
         type=int,
         default=None
     )

--- a/imapbox.py
+++ b/imapbox.py
@@ -12,8 +12,8 @@ def load_configuration(args):
 
     options = {
         'days': config.get('imapbox', 'days', fallback=args.days),
-        'folder': os.path.expanduser(
-            config.get('imapbox', 'folder', fallback=args.folder)
+        'local_folder': os.path.expanduser(
+            config.get('imapbox', 'local_folder', fallback=args.local_folder)
         ),
         'accounts': []
     }
@@ -78,8 +78,8 @@ def main():
     )
     argparser.add_argument(
         '-l',
-        dest='folder',
-        help='Local folder where to create the email folders',
+        dest='local_folder',
+        help='Local folder where to dump emails',
         default='./archive'
     )
     argparser.add_argument(

--- a/imapbox.py
+++ b/imapbox.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
-#-*- coding:utf-8 -*-
+# coding:utf-8
 
-# import mailboxresource
 from mailboxresource import MailboxClient
 import argparse
 from six.moves import configparser
@@ -29,7 +28,6 @@ def load_configuration(args):
         if config.has_option('imapbox', 'wkhtmltopdf'):
             options['wkhtmltopdf'] = os.path.expanduser(config.get('imapbox', 'wkhtmltopdf'))
 
-
     for section in config.sections():
 
         if ('imapbox' == section):
@@ -54,7 +52,7 @@ def load_configuration(args):
         if config.has_option(section, 'remote_folder'):
             account['remote_folder'] = config.get(section, 'remote_folder')
 
-        if (None == account['host'] or None == account['username'] or None == account['password']):
+        if (account['host'] is None or account['username'] is None oraccount['password'] is None):
             continue
 
         options['accounts'].append(account)
@@ -69,8 +67,6 @@ def load_configuration(args):
         options['wkhtmltopdf'] = args.wkhtmltopdf
 
     return options
-
-
 
 
 def main():

--- a/imapbox.py
+++ b/imapbox.py
@@ -114,8 +114,8 @@ def main():
             )
         )
 
-        mailbox = MailboxClient(account, options)
-        stats = mailbox.copy_emails()
+        mailbox = MailboxClient(**account)
+        stats = mailbox.copy_emails(options['days'], options['local_folder'])
         mailbox.cleanup()
 
         print('{}/{}: {} emails created, {} emails already existed'.format(

--- a/imapbox.py
+++ b/imapbox.py
@@ -52,7 +52,7 @@ def load_configuration(args):
         if config.has_option(section, 'remote_folder'):
             account['remote_folder'] = config.get(section, 'remote_folder')
 
-        if (account['host'] is None or account['username'] is None oraccount['password'] is None):
+        if (account['host'] is None or account['username'] is None or account['password'] is None):
             continue
 
         options['accounts'].append(account)
@@ -82,11 +82,11 @@ def main():
 
         print('{}/{} (on {})'.format(account['name'], account['remote_folder'], account['host']))
 
-        mailbox = MailboxClient(account['host'], account['port'], account['username'], account['password'], account['remote_folder'])
-        stats = mailbox.copy_emails(options['days'], options['local_folder'], options['wkhtmltopdf'])
+        mailbox = MailboxClient(account['host'], account['port'], account['username'], account['password'])
+        stats = mailbox.copy_emails(options['days'], options['local_folder'], account['remote_folder'], options['wkhtmltopdf'])
         mailbox.cleanup()
 
-        print('{} emails created, {} emails already exists'.format(stats[0], stats[1]))
+        print('{}/{}: {} emails created, {} emails already existed'.format(account['username'], account['remote_folder'], stats[0], stats[1]))
 
 
 if __name__ == '__main__':

--- a/imapbox.py
+++ b/imapbox.py
@@ -121,7 +121,7 @@ def main():
         )
 
         mailbox = MailboxClient(**account)
-        stats = mailbox.copy_emails(options['days'], options['local_folder'])
+        stats = mailbox.fetch_emails(options['days'], options['local_folder'])
         mailbox.cleanup()
 
         logging.info(

--- a/imapbox.py
+++ b/imapbox.py
@@ -1,9 +1,15 @@
 #!/usr/bin/env python3
 
 import os
+import logging
 import argparse
 import configparser
 from mailboxresource import MailboxClient
+
+logging.basicConfig(
+    format='%(asctime)s - %(levelname)s - %(message)s',
+    level=logging.INFO
+)
 
 
 def load_configuration(args):
@@ -106,24 +112,24 @@ def main():
 
     for account in options['accounts']:
 
-        print('{}/{} (on {}:{})'.format(
+        logging.info(
+            '[%s/%s] start email fetching from %s:%s;',
             account['name'],
             account['remote_folder'],
             account['host'],
             account['port']
-            )
         )
 
         mailbox = MailboxClient(**account)
         stats = mailbox.copy_emails(options['days'], options['local_folder'])
         mailbox.cleanup()
 
-        print('{}/{}: {} emails created, {} emails already existed'.format(
+        logging.info(
+            '[%s/%s] %s emails created, %s emails already existed;',
             account['name'],
             account['remote_folder'],
             stats[0],
             stats[1]
-            )
         )
 
 

--- a/imapbox.py
+++ b/imapbox.py
@@ -8,6 +8,7 @@ from mailboxresource import MailboxClient
 
 logging.basicConfig(
     format='%(asctime)s - %(levelname)s - %(message)s',
+    datefmt='%Y-%m-%dТ%H:%M:%S%z',
     level=logging.INFO
 )
 

--- a/imapbox.py
+++ b/imapbox.py
@@ -9,7 +9,7 @@ import os
 
 def load_configuration(args):
     config = configparser.ConfigParser(allow_no_value=True)
-    config.read(['/etc/imapbox/config.cfg', os.path.expanduser('~/.config/imapbox/config.cfg')])
+    config.read(['config.cfg', '/etc/imapbox/config.cfg', os.path.expanduser('~/.config/imapbox/config.cfg')])
 
     options = {
         'days': None,

--- a/imapbox.py
+++ b/imapbox.py
@@ -1,92 +1,130 @@
-#!/usr/bin/env python
-# coding:utf-8
+#!/usr/bin/env python3
 
-from mailboxresource import MailboxClient
-import argparse
-from six.moves import configparser
 import os
+import argparse
+import configparser
+from mailboxresource import MailboxClient
 
 
 def load_configuration(args):
     config = configparser.ConfigParser(allow_no_value=True)
-    config.read(['config.cfg', '/etc/imapbox/config.cfg', os.path.expanduser('~/.config/imapbox/config.cfg')])
+    config.read(os.path.expanduser(args.config_path))
 
     options = {
-        'days': None,
-        'local_folder': '.',
-        'wkhtmltopdf': None,
+        'days': config.get('imapbox', 'days', fallback=args.days),
+        'folder': os.path.expanduser(
+            config.get('imapbox', 'folder', fallback=args.folder)
+        ),
         'accounts': []
     }
 
-    if (config.has_section('imapbox')):
-        if config.has_option('imapbox', 'days'):
-            options['days'] = config.getint('imapbox', 'days')
+    for section_name in config.sections():
 
-        if config.has_option('imapbox', 'local_folder'):
-            options['local_folder'] = os.path.expanduser(config.get('imapbox', 'local_folder'))
-
-        if config.has_option('imapbox', 'wkhtmltopdf'):
-            options['wkhtmltopdf'] = os.path.expanduser(config.get('imapbox', 'wkhtmltopdf'))
-
-    for section in config.sections():
-
-        if ('imapbox' == section):
+        if (section_name == 'imapbox'):
             continue
 
-        if (args.specific_account and (args.specific_account != section)):
+        if (args.account and (args.account != section_name)):
             continue
 
+        section = config[section_name]
         account = {
-            'name': section,
-            'remote_folder': 'INBOX',
-            'port': 993
+            'name': section_name,
+            'host': section.get('host', args.host),
+            'port': section.get('port', args.port),
+            'username': section.get('username', args.username),
+            'password': section.get('password', args.password),
+            'imap_folder': section.get('imap_folder', args.imap_folder)
         }
-
-        account['host'] = config.get(section, 'host')
-        if config.has_option(section, 'port'):
-            account['port'] = config.get(section, 'port')
-
-        account['username'] = config.get(section, 'username')
-        account['password'] = config.get(section, 'password')
-
-        if config.has_option(section, 'remote_folder'):
-            account['remote_folder'] = config.get(section, 'remote_folder')
 
         if (account['host'] is None or account['username'] is None or account['password'] is None):
             continue
 
         options['accounts'].append(account)
 
-    if (args.local_folder):
-        options['local_folder'] = args.local_folder
-
-    if (args.days):
-        options['days'] = args.days
-
-    if (args.wkhtmltopdf):
-        options['wkhtmltopdf'] = args.wkhtmltopdf
-
     return options
 
 
 def main():
-    argparser = argparse.ArgumentParser(description="Dump a IMAP folder into .eml files")
-    argparser.add_argument('-l', dest='local_folder', help="Local folder where to create the email folders")
-    argparser.add_argument('-d', dest='days', help="Local folder where to create the email folders", type=int)
-    argparser.add_argument('-w', dest='wkhtmltopdf', help="The location of the wkhtmltopdf binary")
-    argparser.add_argument('-a', dest='specific_account', help="Select a specific account to backup")
+    argparser = argparse.ArgumentParser(
+        description='Export messages into .eml files using IMAP protocol'
+    )
+    argparser.add_argument(
+        '-host',
+        dest='host',
+        help='IMAP host'
+    )
+    argparser.add_argument(
+        '-port',
+        dest='port',
+        help='IMAP port',
+        type=int,
+        default=993
+    )
+    argparser.add_argument(
+        '-u',
+        dest='username',
+        help='Username to access email account'
+    )
+    argparser.add_argument(
+        '-p',
+        dest='password',
+        help='Password to access email account'
+    )
+    argparser.add_argument(
+        '-c',
+        dest='config_path',
+        help='Path to configuration file',
+        default='config.ini'
+    )
+    argparser.add_argument(
+        '-l',
+        dest='folder',
+        help='Local folder where to create the email folders',
+        default='./archive'
+    )
+    argparser.add_argument(
+        '-r',
+        dest='imap_folder',
+        help='Remote IMAP folder that should be backed up',
+        default='INBOX'
+    )
+    argparser.add_argument(
+        '-d',
+        dest='days',
+        help='Local folder where to create the email folders',
+        type=int,
+        default=None
+    )
+    argparser.add_argument(
+        '-a',
+        dest='account',
+        help='Select a specific account to backup',
+        default=None
+    )
     args = argparser.parse_args()
     options = load_configuration(args)
 
     for account in options['accounts']:
 
-        print('{}/{} (on {})'.format(account['name'], account['remote_folder'], account['host']))
+        print('{}/{} (on {}:{})'.format(
+            account['name'],
+            account['imap_folder'],
+            account['host'],
+            account['port']
+            )
+        )
 
-        mailbox = MailboxClient(account['host'], account['port'], account['username'], account['password'])
-        stats = mailbox.copy_emails(options['days'], options['local_folder'], account['remote_folder'], options['wkhtmltopdf'])
+        mailbox = MailboxClient(account, options)
+        stats = mailbox.copy_emails()
         mailbox.cleanup()
 
-        print('{}/{}: {} emails created, {} emails already existed'.format(account['username'], account['remote_folder'], stats[0], stats[1]))
+        print('{}/{}: {} emails created, {} emails already existed'.format(
+            account['name'],
+            account['imap_folder'],
+            stats[0],
+            stats[1]
+            )
+        )
 
 
 if __name__ == '__main__':

--- a/mailboxresource.py
+++ b/mailboxresource.py
@@ -81,7 +81,6 @@ class MailboxClient:
 
         self.saved += n_saved
         self.existed += n_existed
-        return (n_saved, n_existed)
 
     def cleanup(self):
         self.mailbox.close()

--- a/mailboxresource.py
+++ b/mailboxresource.py
@@ -90,7 +90,7 @@ class MailboxClient:
         if msg['Message-Id']:
             foldername = re.sub('[^a-zA-Z0-9_\-\.()\s]+', '', msg['Message-Id'])
         else:
-            foldername = hashlib.sha224(data).hexdigest()
+            foldername = hashlib.sha3_256(data).hexdigest()
 
         year = 'None'
         if msg['Date']:

--- a/mailboxresource.py
+++ b/mailboxresource.py
@@ -1,5 +1,5 @@
-#!/usr/bin/env python
 #-*- coding:utf-8 -*-
+#!/usr/bin/env python3
 
 from __future__ import print_function
 

--- a/mailboxresource.py
+++ b/mailboxresource.py
@@ -1,4 +1,3 @@
-#-*- coding:utf-8 -*-
 #!/usr/bin/env python3
 
 from __future__ import print_function

--- a/mailboxresource.py
+++ b/mailboxresource.py
@@ -7,8 +7,14 @@ import re
 import email
 import imaplib
 import hashlib
+import logging
 import datetime
 from message import Message
+
+logging.basicConfig(
+    format='%(asctime)s - %(levelname)s - %(message)s',
+    level=logging.INFO
+)
 
 
 class MailboxClient:
@@ -65,7 +71,7 @@ class MailboxClient:
             else:
                 n_existed += 1
             n_total = len(num)
-        print('{}/{} - {}/{}/{}'.format(self.username, folder.replace('"', ''), n_saved, n_existed, n_total))
+        logging.info('[%s/%s] - saved: %s, existed: %s, total: %s;', self.username, folder.replace('"', ''), n_saved, n_existed, n_total)
         return (n_saved, n_existed)
 
     def cleanup(self):

--- a/mailboxresource.py
+++ b/mailboxresource.py
@@ -97,6 +97,7 @@ class MailboxClient:
 
         year = 'None'
         if msg['Date']:
+            # TODO: replace with datetime.strptime()
             match = re.search('\d{1,2}\s\w{3}\s(\d{4})', msg['Date'])
             if match:
                 year = match.group(1)

--- a/mailboxresource.py
+++ b/mailboxresource.py
@@ -69,7 +69,12 @@ class MailboxClient:
     def saveEmail(self, data):
         for response_part in data:
             if isinstance(response_part, tuple):
-                msg = email.message_from_string(response_part[1].decode("utf-8"))
+                try:
+                    # See: https://docs.python.org/3/howto/unicode.html#python-s-unicode-support
+                    msg = email.message_from_string(response_part[1].decode('utf-8', 'ignore'))
+                except AttributeError:
+                    msg = email.message_from_string(response_part[1])
+
                 directory = self.getEmailFolder(msg, data[0][1])
 
                 if os.path.exists(directory):

--- a/mailboxresource.py
+++ b/mailboxresource.py
@@ -2,12 +2,14 @@
 
 from __future__ import print_function
 
-import imaplib, email
-import re
 import os
+import re
+import email
+import imaplib
 import hashlib
-from message import Message
 import datetime
+from message import Message
+
 
 class MailboxClient:
 

--- a/mailboxresource.py
+++ b/mailboxresource.py
@@ -11,6 +11,7 @@ from email import policy
 from message import Message
 
 logging.basicConfig(
+    filename='imapbox.log',
     format='%(asctime)s - %(levelname)s - %(message)s',
     datefmt='%Y-%m-%dТ%H:%M:%S%z',
     level=logging.INFO

--- a/mailboxresource.py
+++ b/mailboxresource.py
@@ -41,7 +41,8 @@ class MailboxClient:
         criterion = 'ALL'
 
         if days:
-            date = (datetime.date.today() - datetime.timedelta(days)).strftime('%d-%b-%Y')
+            date = datetime.date.today() - datetime.timedelta(days)
+            date = date.strftime('%d-%b-%Y')
             criterion = '(SENTSINCE {date})'.format(date=date)
 
         if self.remote_folder == 'ALL':

--- a/mailboxresource.py
+++ b/mailboxresource.py
@@ -11,6 +11,7 @@ from message import Message
 
 logging.basicConfig(
     format='%(asctime)s - %(levelname)s - %(message)s',
+    datefmt='%Y-%m-%dТ%H:%M:%S%z',
     level=logging.INFO
 )
 

--- a/mailboxresource.py
+++ b/mailboxresource.py
@@ -68,7 +68,16 @@ class MailboxClient:
             else:
                 n_existed += 1
             n_total = len(num)
-        logging.info('[%s/%s] - saved: %s, existed: %s, total: %s;', self.username, folder.replace('"', ''), n_saved, n_existed, n_total)
+
+        logging.info(
+            '[%s/%s] - saved: %s, existed: %s, total: %s;',
+            self.username,
+            folder.replace('"', ''),
+            n_saved,
+            n_existed,
+            n_total
+        )
+
         self.saved += n_saved
         self.existed += n_existed
         return (n_saved, n_existed)

--- a/mailboxresource.py
+++ b/mailboxresource.py
@@ -89,17 +89,17 @@ class MailboxClient:
         self.mailbox.close()
         self.mailbox.logout()
 
-    def get_email_folder(self, msg, data):
-        if msg['Message-Id']:
-            foldername = re.sub('[^a-zA-Z0-9_\-\.\s]+', '', msg['Message-Id'])
+    def get_email_folder(self, message, body):
+        if message['Message-Id']:
+            foldername = re.sub('[^a-zA-Z0-9_\-\.\s]+', '', message['Message-Id'])
             foldername = foldername.strip()
         else:
-            foldername = hashlib.sha3_256(data).hexdigest()
+            foldername = hashlib.sha3_256(body).hexdigest()
 
         year = 'None'
-        if msg['Date']:
-            # TODO: replace with datetime.strptime()
-            match = re.search('\d{1,2}\s\w{3}\s(\d{4})', msg['Date'])
+        if message['Date']:
+            # TODO: replace with email.utils.parsedate()
+            match = re.search('\d{1,2}\s\w{3}\s(\d{4})', message['Date'])
             if match:
                 year = match.group(1)
 

--- a/mailboxresource.py
+++ b/mailboxresource.py
@@ -10,10 +10,7 @@ import hashlib
 from message import Message
 import datetime
 
-
-
 class MailboxClient:
-    """Operations on a mailbox"""
 
     def __init__(self, host, port, username, password, remote_folder):
         self.mailbox = imaplib.IMAP4_SSL(host, port)
@@ -30,7 +27,7 @@ class MailboxClient:
         criterion = 'ALL'
 
         if days:
-            date = (datetime.date.today() - datetime.timedelta(days)).strftime("%d-%b-%Y")
+            date = (datetime.date.today() - datetime.timedelta(days)).strftime('%d-%b-%Y')
             criterion = '(SENTSINCE {date})'.format(date=date)
 
         typ, data = self.mailbox.search(None, criterion)
@@ -43,11 +40,9 @@ class MailboxClient:
 
         return (n_saved, n_exists)
 
-
     def cleanup(self):
         self.mailbox.close()
         self.mailbox.logout()
-
 
     def getEmailFolder(self, msg, data):
         if msg['Message-Id']:
@@ -61,10 +56,7 @@ class MailboxClient:
             if match:
                 year = match.group(1)
 
-
         return os.path.join(self.local_folder, year, foldername)
-
-
 
     def saveEmail(self, data):
         for response_part in data:
@@ -94,10 +86,7 @@ class MailboxClient:
                 except Exception as e:
                     # ex: Unsupported charset on decode
                     print(directory)
-                    if hasattr(e, 'strerror'):
-                        print("MailboxClient.saveEmail() failed:", e.strerror)
-                    else:
-                        print("MailboxClient.saveEmail() failed")
-                        print(e)
+                    print('MailboxClient.saveEmail() failed')
+                    print(e)
 
         return True

--- a/mailboxresource.py
+++ b/mailboxresource.py
@@ -124,7 +124,7 @@ class MailboxClient:
                     message = Message(directory, msg)
                     message.createRawFile(data[0][1])
                     message.createMetaFile()
-                    message.extractAttachments()
+                    message.extract_attachments()
 
                 except Exception as e:
                     # ex: Unsupported charset on decode

--- a/mailboxresource.py
+++ b/mailboxresource.py
@@ -63,13 +63,14 @@ class MailboxClient:
         self.mailbox.select(folder, readonly=True)
 
         status, data = self.mailbox.search(None, criterion)
-        for num in data[0].split():
+        msgnums = data[0].split()
+        n_total = len(msgnums)
+        for num in msgnums:
             status, data = self.mailbox.fetch(num, '(RFC822)')
             if self.save_email(data):
                 n_saved += 1
             else:
                 n_existed += 1
-            n_total = len(num)
 
         logging.info(
             '[%s/%s] - saved: %s, existed: %s, total: %s;',

--- a/mailboxresource.py
+++ b/mailboxresource.py
@@ -115,10 +115,10 @@ class MailboxClient:
 
                 directory = self.get_email_folder(msg, data[0][1])
 
-                if os.path.exists(directory):
+                try:
+                    os.makedirs(directory)
+                except FileExistsError:
                     return False
-
-                os.makedirs(directory)
 
                 try:
                     message = Message(directory, msg)

--- a/mailboxresource.py
+++ b/mailboxresource.py
@@ -88,7 +88,8 @@ class MailboxClient:
 
     def get_email_folder(self, msg, data):
         if msg['Message-Id']:
-            foldername = re.sub('[^a-zA-Z0-9_\-\.()\s]+', '', msg['Message-Id'])
+            foldername = re.sub('[^a-zA-Z0-9_\-\.\s]+', '', msg['Message-Id'])
+            foldername = foldername.strip()
         else:
             foldername = hashlib.sha3_256(data).hexdigest()
 

--- a/mailboxresource.py
+++ b/mailboxresource.py
@@ -13,10 +13,13 @@ from message import Message
 
 class MailboxClient:
 
-    def __init__(self, host, port, username, password, remote_folder):
+    def __init__(self, host, port, username, password):
+        self.username = username
         self.mailbox = imaplib.IMAP4_SSL(host, port)
-        self.mailbox.login(username, password)
-        self.mailbox.select(remote_folder, readonly=True)
+        try:
+            self.mailbox.login(username, password)
+        except imaplib.IMAP4.error:
+            print('Unable to login to: ', username)
 
     def copy_emails(self, days, local_folder, wkhtmltopdf):
 

--- a/mailboxresource.py
+++ b/mailboxresource.py
@@ -1,7 +1,5 @@
 #!/usr/bin/env python3
 
-from __future__ import print_function
-
 import os
 import re
 import email
@@ -28,6 +26,7 @@ class MailboxClient:
         self.remote_folder = remote_folder
 
         self.mailbox = imaplib.IMAP4_SSL(self.host, self.port)
+
         try:
             self.mailbox.login(self.username, self.password)
         except imaplib.IMAP4.error:
@@ -36,9 +35,9 @@ class MailboxClient:
     def copy_emails(self, days, local_folder):
         self.days = days
         self.local_folder = local_folder
+        self.saved = 0
+        self.existed = 0
 
-        t_saved = 0
-        t_existed = 0
         criterion = 'ALL'
 
         if days:
@@ -49,14 +48,10 @@ class MailboxClient:
             for i in self.mailbox.list()[1]:
                 folder = i.decode().split(' "/" ')[1]
                 n_saved, n_existed = self.fetch_emails(folder, criterion)
-                t_saved += n_saved
-                t_existed += n_existed
         else:
             n_saved, n_existed = self.fetch_emails(self.remote_folder, criterion)
-            t_saved += n_saved
-            t_existed += n_existed
 
-        return (t_saved, t_existed)
+        return (self.saved, self.existed)
 
     def fetch_emails(self, folder, criterion):
         n_saved = 0
@@ -72,6 +67,8 @@ class MailboxClient:
                 n_existed += 1
             n_total = len(num)
         logging.info('[%s/%s] - saved: %s, existed: %s, total: %s;', self.username, folder.replace('"', ''), n_saved, n_existed, n_total)
+        self.saved += n_saved
+        self.existed += n_existed
         return (n_saved, n_existed)
 
     def cleanup(self):

--- a/mailboxresource.py
+++ b/mailboxresource.py
@@ -33,7 +33,6 @@ class MailboxClient:
 
         t_saved = 0
         t_existed = 0
-        self.wkhtmltopdf = wkhtmltopdf
         criterion = 'ALL'
 
         if days:
@@ -109,8 +108,6 @@ class MailboxClient:
                     message.createMetaFile()
                     message.extractAttachments()
 
-                    if self.wkhtmltopdf:
-                        message.createPdfFile(self.wkhtmltopdf)
                 except Exception as e:
                     # ex: Unsupported charset on decode
                     print(directory)

--- a/message.py
+++ b/message.py
@@ -78,40 +78,40 @@ class Message:
     def getmailheader(self, header_text, default="ascii"):
         """Decode header_text if needed"""
         try:
-            headers=decode_header(header_text)
+            headers = decode_header(header_text)
         except email.Errors.HeaderParseError:
             # This already append in email.base64mime.decode()
             # instead return a sanitized ascii string
             return header_text.encode('ascii', 'replace').decode('ascii')
         else:
             for i, (text, charset) in enumerate(headers):
-                headers[i]=text
+                headers[i] = text
                 if charset:
-                    headers[i]=str(text, charset)
+                    headers[i] = str(text, charset)
                 else:
-                    headers[i]=str(text)
+                    headers[i] = str(text)
             return u"".join(headers)
 
 
     def getmailaddresses(self, prop):
         """retrieve From:, To: and Cc: addresses"""
-        addrs=email.utils.getaddresses(self.msg.get_all(prop, []))
+        addrs = email.utils.getaddresses(self.msg.get_all(prop, []))
         for i, (name, addr) in enumerate(addrs):
             if not name and addr:
                 # only one string! Is it the address or is it the name ?
                 # use the same for both and see later
-                name=addr
+                name = addr
 
             try:
                 # address must be ascii only
-                addr=addr.encode('ascii')
+                addr = addr.encode('ascii')
             except UnicodeError:
-                addr=''
+                addr = ''
             else:
                 # address must match adress regex
                 if not email_address_re.match(addr.decode("utf-8")):
-                    addr=''
-            addrs[i]=(self.getmailheader(name), addr.decode("utf-8"))
+                    addr = ''
+            addrs[i] = (self.getmailheader(name), addr.decode("utf-8"))
         return addrs
 
     def getSubject(self):
@@ -136,8 +136,8 @@ class Message:
         return (rfc2822, iso8601)
 
     def createMetaFile(self):
-        tos=self.getmailaddresses('to')
-        ccs=self.getmailaddresses('cc')
+        tos = self.getmailaddresses('to')
+        ccs = self.getmailaddresses('cc')
 
         parts = self.getParts()
         attachments = []
@@ -157,12 +157,12 @@ class Message:
         with io.open('%s/metadata.json' %(self.directory), 'w', encoding='utf8') as json_file:
             data = json.dumps({
                 'Id': self.msg['Message-Id'],
-                'Subject' : self.getSubject(),
-                'From' : self.getFrom(),
-                'To' : tos,
-                'Cc' : ccs,
-                'Date' : rfc2822,
-                'Utc' : iso8601,
+                'Subject': self.getSubject(),
+                'From': self.getFrom(),
+                'To': tos,
+                'Cc': ccs,
+                'Date': rfc2822,
+                'Utc': iso8601,
                 'Attachments': attachments,
                 'WithHtml': len(parts['html']) > 0,
                 'WithText': len(parts['text']) > 0,
@@ -173,20 +173,15 @@ class Message:
 
             json_file.close()
 
-
-
-
     def createRawFile(self, data):
         f = gzip.open('%s/raw.eml.gz' %(self.directory), 'wb')
         f.write(data)
         f.close()
 
-
     def getPartCharset(self, part):
         if part.get_content_charset() is None:
             return chardet.detect(str(part))['encoding']
         return part.get_content_charset()
-
 
     def getTextContent(self, parts):
         if not hasattr(self, 'text_content'):
@@ -196,7 +191,6 @@ class Message:
                 charset = self.getPartCharset(part)
                 self.text_content += raw_content.decode(charset, "replace")
         return self.text_content
-
 
     def createTextFile(self, parts):
         utf8_content = self.getTextContent(parts)
@@ -217,7 +211,6 @@ class Message:
                 self.html_content = m.group(1)
 
         return self.html_content
-
 
     def createHtmlFile(self, parts, embed):
         utf8_content = self.getHtmlContent(parts)

--- a/message.py
+++ b/message.py
@@ -292,7 +292,7 @@ class Message:
         return self.message_parts
 
 
-    def extractAttachments(self):
+    def extract_attachments(self):
         message_parts = self.getParts()
 
         if message_parts['text']:

--- a/message.py
+++ b/message.py
@@ -310,13 +310,3 @@ class Message:
                     payload = afile[0].get_payload(decode=True)
                     if payload:
                         fp.write(payload)
-
-
-    def createPdfFile(self, wkhtmltopdf):
-        if has_pdfkit:
-            html_path = os.path.join(self.directory, 'message.html')
-            pdf_path = os.path.join(self.directory, 'message.pdf')
-            config = pdfkit.configuration(wkhtmltopdf=wkhtmltopdf)
-            pdfkit.from_file(html_path, pdf_path, configuration=config)
-        else:
-            print("Couldn't create PDF message, since \"pdfkit\" module isn't installed.")

--- a/message.py
+++ b/message.py
@@ -303,10 +303,14 @@ class Message:
 
         if message_parts['files']:
             attdir = os.path.join(self.directory, 'attachments')
-            if not os.path.exists(attdir):
+
+            try:
                 os.makedirs(attdir)
-            for afile in message_parts['files']:
-                with open(os.path.join(attdir, afile[1]), 'wb') as fp:
-                    payload = afile[0].get_payload(decode=True)
+            except FileExistsError:
+                pass
+
+            for file in message_parts['files']:
+                with open(os.path.join(attdir, file[1]), 'wb') as fp:
+                    payload = file[0].get_payload(decode=True)
                     if payload:
                         fp.write(payload)


### PR DESCRIPTION
This PR fixes two main problems in python 3 with email content decoding during fetch:
1. decode only bytes and falloff to strings
2. ignore unknown to UTF-8 bytes with `ignore` error handler