### PR TITLE
Make it optional to store password in config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Parameter       | Description
 ----------------|----------------------
 host            | IMAP server hostname
 username        | Login id for the IMAP server.
-password        | The password will be saved in cleartext, for security reasons, you have to run the imapbox script in userspace and set `chmod 700` on your `~/.config/mailbox/config.cfg` file.
+password        | (optional) The password will be saved in cleartext, for security reasons, you have to run the imapbox script in userspace and set `chmod 700` on your `~/.config/mailbox/config.cfg` file. The user will prompted for a password if this parameter is missing.
 remote_folder   | (optional) IMAP folder name (multiple folder name is not supported for the moment). Default value is `INBOX`. You can use `__ALL__` to fetch all folders.
 port            | (optional) Default value is `993`.
 

--- a/imapbox.py
+++ b/imapbox.py
@@ -5,6 +5,7 @@ from mailboxresource import save_emails, get_folder_fist
 import argparse
 from six.moves import configparser
 import os
+import getpass
 
 
 def load_configuration(args):
@@ -48,7 +49,11 @@ def load_configuration(args):
             account['port'] = config.get(section, 'port')
 
         account['username'] = config.get(section, 'username')
-        account['password'] = config.get(section, 'password')
+        if config.has_option(section, 'password'):
+            account['password'] = config.get(section, 'password')
+        else:
+            prompt=('Password for ' + account['username'] + ':' + account['host'] + ': ')
+            account['password'] = getpass.getpass(prompt=prompt)
 
         if config.has_option(section, 'remote_folder'):
             account['remote_folder'] = config.get(section, 'remote_folder')


### PR DESCRIPTION
Prompt user for password when the parameter is missing in the config file.