### PR TITLE
Support multiple remote_folders & Handle malformed Message-Id properly

### DIFF
--- a/imapbox.py
+++ b/imapbox.py
@@ -94,16 +94,18 @@ def main():
     for account in options['accounts']:
 
         print('{}/{} (on {})'.format(account['name'], account['remote_folder'], account['host']))
+        basedir = options['local_folder']
 
         if account['remote_folder'] == "__ALL__":
-            basedir = options['local_folder']
+            folders = []
             for folder_entry in get_folder_fist(account):
-                folder_name = folder_entry.decode().replace("/",".").split(' "." ')
-                print("Saving folder: " + folder_name[1])
-                account['remote_folder'] = folder_name[1]
-                options['local_folder'] = os.path.join(basedir, account['remote_folder'])
-                save_emails(account, options)
+                folders.append(folder_entry.decode().replace("/",".").split(' "." ')[1])
         else:
+            folders = str.split(account['remote_folder'], ',')
+        for folder_entry in folders:
+            print("Saving folder: " + folder_entry) 
+            account['remote_folder'] = folder_entry
+            options['local_folder'] = os.path.join(basedir, folder_entry.replace('"', ''))
             save_emails(account, options)
 
 if __name__ == '__main__':

--- a/mailboxresource.py
+++ b/mailboxresource.py
@@ -62,7 +62,7 @@ class MailboxClient:
 
     def getEmailFolder(self, msg, data):
         if msg['Message-Id']:
-            foldername = re.sub('[^a-zA-Z0-9_\-\.()\s]+', '', msg['Message-Id'])
+            foldername = re.sub('[^a-zA-Z0-9_\-\.() ]+', '', msg['Message-Id'])
         else:
             foldername = hashlib.sha224(data).hexdigest()
 


### PR DESCRIPTION
# Support multiple remote_folders
This commit make it possible to specify multiple `remote_folder`s in a single account config. Which is handy in specified scenarios.
```ini
[accountX]
remote_folder=INBOX,Archive,"FolderName with s p a c e"
```

# Handle malformed Message-Id properly
I just found a weird mail in my outlook inbox. The `Message-Id` contains a `\r\n\t` for some reason, which crashes the script since the \r\n\t isn't valid character for paths.

![snipaste_20211215_200242](https://user-images.githubusercontent.com/31540475/146185544-283534e1-0678-4fb0-88c3-3c0b07157e33.png)

Therefore, I patched the regex and replaced `\s` (which [means](https://docs.python.org/3/library/re.html) `[ \t\n\r\f\v]` and only the space is valid path character) with a space, and it worked like a charm :)

