### PR TITLE
Fix attachments path on Windows (backslash)

### DIFF
--- a/message.py
+++ b/message.py
@@ -7,6 +7,7 @@ from email.utils import parseaddr
 from email.header import decode_header
 import re
 import os
+import posixpath
 import sys
 import json
 import io
@@ -240,7 +241,7 @@ class Message:
         utf8_content = self.getHtmlContent(parts)
         for img in embed:
             pattern = 'src=["\']cid:%s["\']' % (re.escape(img[0]))
-            path = os.path.join('attachments', img[1])
+            path = posixpath.join('attachments', img[1])
             utf8_content = re.sub(pattern, 'src="%s"' % (path), utf8_content, 0, re.S | re.I)
 
 


### PR DESCRIPTION
This patch fixes the attachment path on Windows.

In the HTML content generation, embedded images are replaced by paths to the files.
The paths are joined together with `os.path.join`, which uses backslashes (`\`) on Windows systems. For example `attachments\part-001.png`.
These backslashes are interpreted by `re.sub` as escape characters and cause an exception.

`re.sub` [docs.python.org](https://docs.python.org/3/library/re.html#re.sub):
>  *repl* can be a string or a function; if it is a string, any backslash escapes in it are processed.
>  Unknown escapes of ASCII letters are reserved for future use and treated as errors.

This is fixed by using `posixpath` (which uses `/`). 
Additionally, this also avoids "Windows paths" in the HTML source.


Note: `posixpath` requires a minimum python version of 3.4.

---

Error (with extra `traceback.print_exc()`)
```php
Traceback (most recent call last):
  File "C:\Program Files\Python39\lib\sre_parse.py", line 1039, in parse_template
    this = chr(ESCAPES[this][1])
KeyError: '\\p'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "\imapbox\mailboxresource.py", line 107, in saveEmail
    message.extractAttachments()
  File "\imapbox\message.py", line 326, in extractAttachments
    self.createHtmlFile(message_parts['html'], message_parts['embed_images'])
  File "\imapbox\message.py", line 244, in createHtmlFile
    utf8_content = re.sub(pattern, 'src="%s"' % (path), utf8_content, 0, re.S | re.I)
  File "C:\Program Files\Python39\lib\re.py", line 210, in sub
    return _compile(pattern, flags).sub(repl, string, count)
  File "C:\Program Files\Python39\lib\re.py", line 327, in _subx
    template = _compile_repl(template, pattern)
  File "C:\Program Files\Python39\lib\re.py", line 318, in _compile_repl
    return sre_parse.parse_template(repl, pattern)
  File "C:\Program Files\Python39\lib\sre_parse.py", line 1042, in parse_template
    raise s.error('bad escape %s' % this, len(this))
re.error: bad escape \p at position 16
...
MailboxClient.saveEmail() failed
```