### PR TITLE
Add support for handling Gmail accounts

### DIFF
--- a/imapbox.py
+++ b/imapbox.py
@@ -100,6 +100,10 @@ def main():
             folders = []
             for folder_entry in get_folder_fist(account):
                 folders.append(folder_entry.decode().replace("/",".").split(' "." ')[1])
+            # Remove Gmail parent folder from array otherwise the script fails:
+            if '"[Gmail]"' in folders: folders.remove('"[Gmail]"')
+            # Remove Gmail "All Mail" folder which just duplicates emails:
+            if '"[Gmail].All Mail"' in folders: folders.remove('"[Gmail].All Mail"')
         else:
             folders = str.split(account['remote_folder'], ',')
         for folder_entry in folders:


### PR DESCRIPTION
This PR adds support for Gmail accounts which fixes the issue described in #31 

I've tested it with my Fastmail account and my wife's Gmail account, which has 34,000+ emails, and the script downloaded everything without issue as far as I can tell.

There may also be some debate on whether the "`[Gmail].All Mail`" folder should be excluded, but from the testing I've done, it appears to just end up duplicating emails, as it contains _all the mail_, so everything in the Inbox, Sent Mail and more.

Bit more info on "All Mail" here: [here](https://old.reddit.com/r/Thunderbird/comments/r5nloo/all_incoming_messages_are_duplicated_inside_all/) and `[here](https://support.mozilla.org/en-US/kb/thunderbird-and-gmail#w_subscribing-to-or-unsubscribing-from-folders-labels`.

