### PR TITLE
fixed https://github.com/polo2ro/imapbox/issues/47

### DIFF
--- a/mailboxresource.py
+++ b/mailboxresource.py
@@ -61,7 +61,8 @@ class MailboxClient:
 
 
     def getEmailFolder(self, msg, data):
-        if msg['Message-Id']:
+        # 255is the max filename length on all systems
+        if msg['Message-Id'] and len(msg['Message-Id']) < 255:
             foldername = re.sub('[^a-zA-Z0-9_\-\.() ]+', '', msg['Message-Id'])
         else:
             foldername = hashlib.sha224(data).hexdigest()


### PR DESCRIPTION
Fixed https://github.com/polo2ro/imapbox/issues/47

Problem:

IONOS and other providers provide message-ids, when taken as filename, are too long for any filesystem.

Solution:

Extend the no-message-id-use-hash solution to include too-long-message-ids.


<!-- insert PR description above -->
-----
<a href="https://stackblitz.com/~/github.com/BananaAcid/imapbox/tree/BananaAcid/patch-81302-imapbox-fix-max-filesize"><img src="https://developer.stackblitz.com/img/review_pr_small.svg" alt="Review PR in StackBlitz" align="left" width="103" height="20"></a> _Submitted with [StackBlitz](https://stackblitz.com/~/github.com/BananaAcid/imapbox/tree/BananaAcid/patch-81302-imapbox-fix-max-filesize)._