### PR TITLE
added shell arg to allow providing a config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ This script requires Python 3.4 for `master` branch or python 2 on the `python2`
 
 Use `./config.cfg` `~/.config/imapbox/config.cfg` or `/etc/imapbox/config.cfg`
 
+Alternatively specifiy the shell argument `-c` to provide the path to a config file. E.g. `-c ./config.client1.cfg`
+
 Example:
 ```ini
 [imapbox]

--- a/imapbox.py
+++ b/imapbox.py
@@ -10,7 +10,11 @@ import getpass
 
 def load_configuration(args):
     config = configparser.ConfigParser(allow_no_value=True)
-    config.read(['./config.cfg', '/etc/imapbox/config.cfg', os.path.expanduser('~/.config/imapbox/config.cfg')])
+    if (args.specific_config):
+        locations = args.specific_config
+    else:
+        locations = ['./config.cfg', '/etc/imapbox/config.cfg', os.path.expanduser('~/.config/imapbox/config.cfg')]
+    config.read(locations)
 
     options = {
         'days': None,
@@ -96,6 +100,7 @@ def main():
     argparser.add_argument('-w', dest='wkhtmltopdf', help="The location of the wkhtmltopdf binary")
     argparser.add_argument('-a', dest='specific_account', help="Select a specific account to backup")
     argparser.add_argument('-f', dest='specific_folders', help="Backup into specific account subfolders")
+    argparser.add_argument('-c', dest='specific_config', help="Path to a config file to use")
     args = argparser.parse_args()
     options = load_configuration(args)
     rootDir = options['local_folder']


### PR DESCRIPTION
Since I got a folder full of config files for different account combinations, that get configured by a UI, I needed the option to trigger imapbox with different config files in parallel. 

<!-- insert PR description above -->
-----
<a href="https://stackblitz.com/~/github.com/BananaAcid/imapbox/tree/BananaAcid/patch-35830-imapbox-fix-specify-config"><img src="https://developer.stackblitz.com/img/review_pr_small.svg" alt="Review PR in StackBlitz" align="left" width="103" height="20"></a> _Submitted with [StackBlitz](https://stackblitz.com/~/github.com/BananaAcid/imapbox/tree/BananaAcid/patch-35830-imapbox-fix-specify-config)._