### PR TITLE
fix `f` shell arg  not needing a keyword/value like `True`

### DIFF
--- a/imapbox.py
+++ b/imapbox.py
@@ -95,7 +95,7 @@ def main():
     argparser.add_argument('-d', dest='days', help="Number of days back to get in the IMAP account", type=int)
     argparser.add_argument('-w', dest='wkhtmltopdf', help="The location of the wkhtmltopdf binary")
     argparser.add_argument('-a', dest='specific_account', help="Select a specific account to backup")
-    argparser.add_argument('-f', dest='specific_folders', help="Backup into specific account subfolders")
+    argparser.add_argument('-f', dest='specific_folders', help="Backup into specific account subfolders", action='store_true')
     args = argparser.parse_args()
     options = load_configuration(args)
     rootDir = options['local_folder']


### PR DESCRIPTION
My bad, added the args info to work without a value

`-f True` can now be `-f` to work, which is way more common. 


<!-- insert PR description above -->
-----
<a href="https://stackblitz.com/~/github.com/BananaAcid/imapbox/tree/BananaAcid/patch-48312-fix-param-type"><img src="https://developer.stackblitz.com/img/review_pr_small.svg" alt="Review PR in StackBlitz" align="left" width="103" height="20"></a> _Submitted with [StackBlitz](https://stackblitz.com/~/github.com/BananaAcid/imapbox/tree/BananaAcid/patch-48312-fix-param-type)._