### PR TITLE
add test only mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ local_folder    | The full path to the folder where the emails should be stored.
 days            | Number of days back to get in the IMAP account, this should be set greater and equals to the cronjob frequency. If this parameter is not set, imapbox will get all the emails from the IMAP account. This can be overwritten with the shell argument `-d`.
 wkhtmltopdf     | (optional) The location of the `wkhtmltopdf` binary. By default `pdfkit` will attempt to locate this using `which` (on UNIX type systems) or `where` (on Windows). This can be overwritten with the shell argument `-w`.
 specific_folders| (optional) Backup into specific account subfolders. By default all accounts will be combined into one account folder. This can be overwritten with the shell argument `-f`.
+test_only       | (optional) Only a connection and folder retrival test will be performed. This can be overwritten with the shell argument `-t`.
 
 ### Other sections
 

--- a/imapbox.py
+++ b/imapbox.py
@@ -17,6 +17,7 @@ def load_configuration(args):
         'local_folder': '.',
         'wkhtmltopdf': None,
         'specific_folders': False,
+        'test_only': False,
         'accounts': []
     }
 
@@ -32,6 +33,9 @@ def load_configuration(args):
 
         if config.has_option('imapbox', 'specific_folders'):
             options['specific_folders'] = config.getboolean('imapbox', 'specific_folders')
+
+        if config.has_option('imapbox', 'test_only'):
+            options['test_only'] = config.getboolean('imapbox', 'test_only')
 
 
     for section in config.sections():
@@ -84,6 +88,9 @@ def load_configuration(args):
     if (args.specific_folders):
         options['specific_folders'] = True
 
+    if (args.test_only):
+        options['test_only'] = True
+
     return options
 
 
@@ -96,6 +103,7 @@ def main():
     argparser.add_argument('-w', dest='wkhtmltopdf', help="The location of the wkhtmltopdf binary")
     argparser.add_argument('-a', dest='specific_account', help="Select a specific account to backup")
     argparser.add_argument('-f', dest='specific_folders', help="Backup into specific account subfolders")
+    argparser.add_argument('-t', dest='test_only', help="Only a connection and folder retrival test will be performed", action='store_true')
     args = argparser.parse_args()
     options = load_configuration(args)
     rootDir = options['local_folder']
@@ -103,7 +111,14 @@ def main():
     for account in options['accounts']:
 
         print('{}/{} (on {})'.format(account['name'], account['remote_folder'], account['host']))
-        basedir = options['local_folder']
+
+        if options['test_only']:
+            try:
+                get_folder_fist(account)
+                print(" - SUCCESS: Login and folder retrival")
+            except:
+                print("\x1b[31;20m" + " - FAILED: Login and folder retrival" + "\x1b[0m")
+            continue
 
         if options['specific_folders']:
             basedir = os.path.join(rootDir, account['name'])


### PR DESCRIPTION
A shell arg `-t` that only tests connections and if folders can be retrieved. To validate accounts.

I have a lot of accounts I want to test before having them run (some INBOXes are really really large, it takes time to check if there is a login problem)

<!-- insert PR description above -->
-----
<a href="https://stackblitz.com/~/github.com/BananaAcid/imapbox/tree/master"><img src="https://developer.stackblitz.com/img/review_pr_small.svg" alt="Review PR in StackBlitz" align="left" width="103" height="20"></a> _Submitted with [StackBlitz](https://stackblitz.com/~/github.com/BananaAcid/imapbox/tree/master)._